### PR TITLE
[bug] theme titles can overflow into the .tabs element

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -65,7 +65,10 @@ input {
 	color: #000;
 	display: block;
 	font-size: 28px;
+	overflow: hidden;
+	text-overflow: ellipsis;
 	text-transform: capitalize;
+	white-space: nowrap;
 }
 #sidebar .tabs {
 	overflow: hidden;


### PR DESCRIPTION
## Demo

![screen shot 2014-10-03 at 3 20 33 pm](https://cloud.githubusercontent.com/assets/1154834/4513279/a75ac9ea-4b4a-11e4-9968-b5725913b28f.png)
## Fixed

![screen shot 2014-10-03 at 3 20 22 pm](https://cloud.githubusercontent.com/assets/1154834/4513280/a9807184-4b4a-11e4-988a-bb2c8c7f7dc9.png)
