### PR TITLE
Change `uglify` to run the local install of grunt

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,12 @@ The live editor available at http://registry.jsonresume.org/
 
 ## Development
 
-### Using Grunt
-
-Install [Grunt](http://gruntjs.com/):
-
-```
-sudo npm -g install grunt-cli
-```
-
-When that is done, run `npm install` while standing in the repository folder.
+Run `npm install` from the root of the repository folder.
 
 You can now concat the files:
 
 ```
-grunt uglify
+npm run uglify
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-uglify": "^0.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "url": "http://github.com/erming/resume-editor"
   },
   "license": "MIT",
+  "scripts": {
+    "uglify": "grunt uglify"
+  },
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-contrib-uglify": "^0.5.1"


### PR DESCRIPTION
This change removes the requirement to install grunt globally.

Fixes #23

Additional justification is outlined in the attached issue.
